### PR TITLE
Add httparty and addressable gems as runtime dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bundle
+*.gem
 *.db
 *~
 *#

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,12 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.4)
-    coderay (1.0.9)
     diff-lcs (1.2.2)
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    method_source (0.8.2)
     multi_json (1.7.3)
     multi_xml (0.5.3)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -22,7 +16,6 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.0)
-    slop (3.4.6)
 
 PLATFORMS
   ruby
@@ -30,5 +23,4 @@ PLATFORMS
 DEPENDENCIES
   addressable
   httparty
-  pry
   rspec

--- a/open_weather.gemspec
+++ b/open_weather.gemspec
@@ -14,4 +14,7 @@ Gem::Specification.new do |gem|
   gem.executables          = gem.files.grep(/^bin/).map{ |f| File.basename(f) }
   gem.require_paths        = ["lib"]
   gem.add_development_dependency "rspec"
+
+  gem.add_runtime_dependency 'httparty'
+  gem.add_runtime_dependency 'addressable'
 end


### PR DESCRIPTION
- After `gem install open_weather`, I got error: `LoadError: cannot load such file -- httparty`. Added the gems ad development dependency.
- Exclude *.gem files from git.
