### PR TITLE
Add units options

### DIFF
--- a/lib/open_weather/base.rb
+++ b/lib/open_weather/base.rb
@@ -24,7 +24,7 @@ module OpenWeather
     private
 
     def extract_options!(options)
-      valid_options = [:lat, :lon, :city, :country, :id]
+      valid_options = [:lat, :lon, :city, :country, :id, :units]
       options.keys.each { |k| options.delete(k) unless valid_options.include?(k) }
 
       if options[:city] || options[:country]


### PR DESCRIPTION
openweathermap accept `units` options like this

```
http://api.openweathermap.org/data/2.5/weather?q=Tokyo,jp&units=metric
```

This option switch temperature coding. Very useful for me.
documentation: http://bugs.openweathermap.org/projects/api/wiki/Api_2_5_weather#4-Other-parameters
