### PR TITLE
Fix 'retrieve' and 'usage' typos in API/Base

### DIFF
--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -2,20 +2,20 @@
 module OpenWeather
   module ClassMethods
     # City format : Eg, Cochin,IN
-    # Useage: OpenWeather::Current.city('Cochin,In')
+    # Usage: OpenWeather::Current.city('Cochin,In')
     def city(city, options = {})
-      new(options.merge(city: city)).retrive
+      new(options.merge(city: city)).retrieve
     end
 
     # City Id, an integer value. Eg, 2172797
-    # Useage: OpenWeather::Current.city_id(2172797)
+    # Usage: OpenWeather::Current.city_id(2172797)
     def city_id(id, options = {})
-      new(options.merge(id: id)).retrive
+      new(options.merge(id: id)).retrieve
     end
 
     # City Geographics Cordingates : Eg, lat 35 lon 139
     def geocode(lat, lon, options = {})
-      new(options.merge(lat: lat, lon: lon)).retrive
+      new(options.merge(lat: lat, lon: lon)).retrieve
     end
   end
 

--- a/lib/open_weather/base.rb
+++ b/lib/open_weather/base.rb
@@ -12,7 +12,7 @@ module OpenWeather
       @options = extract_options!(options)
     end
 
-    def retrive
+    def retrieve
       response = send_request unless @options.empty?
       parse_response(response)
     end


### PR DESCRIPTION
Changed `retrive` to `retrieve` in `base.rb` / `api.rb`.

Changed `useage` to `usage` in `api.rb`.

Had to `bundle update` for the tests to run (`safe_yaml` error). All tests ran except for the `RSpec` version test. I did not commit the updated `Gemfile.lock` or fixed test as I thought they were unrelated to this change.