### PR TITLE
Support API calls for several cities

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ OpenWeather::Current.city_id("1273874")
 # get current weather by geocode. (lat, lon)
 OpenWeather::Current.geocode(9.94, 76.26)
 
+# get current weather for a list of city ids
+OpenWeather::Current.cities([524901,703448,2643743])
+
 # get the current weather in degrees celsius
 OpenWeather::Current.city("Cochin, IN", units: 'metric')
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-Latest version `0.11.0`
+Latest version `0.12.0`
 
 Add the following to your **Gemfile**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ OpenWeather::Current.city_id("1273874")
 OpenWeather::Current.geocode(9.94, 76.26)
 
 # get current weather for a list of city ids
-OpenWeather::Current.cities([524901,703448,2643743])
+OpenWeather::Current.cities([524901, 703448, 2643743])
+
+# get current weather for a bounding box
+OpenWeather::Current.rectangle_zone(12, 32, 15, 37, 10)
+
+# get current weather for cities around a point
+OpenWeather::Current.circle_zone(55.5, 37.5, 10)
 
 # get the current weather in degrees celsius
 OpenWeather::Current.city("Cochin, IN", units: 'metric')

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -19,7 +19,21 @@ module OpenWeather
     end
   end
 
+  module SeveralCitiesClassMethods
+    # City Ids, an array of integer values. Eg, [2172797, 524901]
+    # Usage: OpenWeather::Current.cities([2172797, 524901])
+    def cities(ids, options = {})
+      url = 'http://api.openweathermap.org/data/2.5/group'
+      ids = ids.join ',' # get comma-separated list, as required by the API
+      new(options.merge(id: ids)).retrieve url
+    end
+  end
+
   class Base
     extend ClassMethods
+  end
+
+  class Current
+    extend SeveralCitiesClassMethods
   end
 end

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -31,7 +31,8 @@ module OpenWeather
     # Bounding box (lat and lon of top left and bottom right points, map zoom)
     # Usage: OpenWeather::Current.rectangle_zone(12,32,15,37,10)
     def rectangle_zone(top_left_lat, top_left_lon,
-                       bottom_right_lat, bottom_right_lon, map_zoom)
+                       bottom_right_lat, bottom_right_lon,
+                       map_zoom, options = {})
       url = 'http://api.openweathermap.org/data/2.5/box/city'
       bbox = encode_array [top_left_lat, top_left_lon, bottom_right_lat,
               bottom_right_lon, map_zoom]

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -39,6 +39,13 @@ module OpenWeather
       new(options.merge(bbox: bbox)).retrieve url
     end
 
+    # Circle zone (lat, lon and count of cities to return)
+    # Usage: OpenWeather::Current.circle_zone(55.5, 37.5, 10)
+    def circle_zone(lat, lon, count, options = {})
+      url = 'http://api.openweathermap.org/data/2.5/find'
+      new(options.merge(lat: lat, lon: lon, cnt: count)).retrieve url
+    end
+
     private
     # Encodes an array in the format expected by the API (comma-separated list)
     def encode_array(arr)

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -24,8 +24,24 @@ module OpenWeather
     # Usage: OpenWeather::Current.cities([2172797, 524901])
     def cities(ids, options = {})
       url = 'http://api.openweathermap.org/data/2.5/group'
-      ids = ids.join ',' # get comma-separated list, as required by the API
+      ids = encode_array ids
       new(options.merge(id: ids)).retrieve url
+    end
+
+    # Bounding box (lat and lon of top left and bottom right points, map zoom)
+    # Usage: OpenWeather::Current.rectangle_zone(12,32,15,37,10)
+    def rectangle_zone(top_left_lat, top_left_lon,
+                       bottom_right_lat, bottom_right_lon, map_zoom)
+      url = 'http://api.openweathermap.org/data/2.5/box/city'
+      bbox = encode_array [top_left_lat, top_left_lon, bottom_right_lat,
+              bottom_right_lon, map_zoom]
+      new(options.merge(bbox: bbox)).retrieve url
+    end
+
+    private
+    # Encodes an array in the format expected by the API (comma-separated list)
+    def encode_array(arr)
+      arr.join ','
     end
   end
 

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -29,7 +29,7 @@ module OpenWeather
     end
 
     # Bounding box (lat and lon of top left and bottom right points, map zoom)
-    # Usage: OpenWeather::Current.rectangle_zone(12,32,15,37,10)
+    # Usage: OpenWeather::Current.rectangle_zone(12, 32, 15, 37, 10)
     def rectangle_zone(top_left_lat, top_left_lon,
                        bottom_right_lat, bottom_right_lon,
                        map_zoom, options = {})

--- a/lib/open_weather/base.rb
+++ b/lib/open_weather/base.rb
@@ -12,8 +12,8 @@ module OpenWeather
       @options = extract_options!(options)
     end
 
-    def retrieve
-      response = send_request unless @options.empty?
+    def retrieve(url=nil)
+      response = send_request url unless @options.empty?
       parse_response(response)
     end
 
@@ -46,8 +46,9 @@ module OpenWeather
       @weather_info
     end
 
-    def send_request
-      uri       = URI(@url)
+    def send_request(url=nil)
+      url       = url || @url
+      uri       = URI(url)
       uri.query = URI.encode_www_form(options)
       Net::HTTP.get(uri)
     end

--- a/lib/open_weather/base.rb
+++ b/lib/open_weather/base.rb
@@ -25,7 +25,7 @@ module OpenWeather
 
     def extract_options!(options)
       valid_options = [ :id, :lat, :lon, :cnt, :city, :lang, :units, :APPID,
-        :country]
+        :country, :bbox]
 
       options.keys.each { |k| options.delete(k) unless valid_options.include?(k) }
 

--- a/lib/open_weather/version.rb
+++ b/lib/open_weather/version.rb
@@ -1,3 +1,3 @@
 module OpenWeather
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/fixtures/cassettes/api/current_circle_zone_invalid.yml
+++ b/spec/fixtures/cassettes/api/current_circle_zone_invalid.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/find?cnt=-10&lat=55.5&lon=37.5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 15:03:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - redis
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"message":"exception: limit must be >=0","cod":"500"}
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 15:03:11 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/api/current_circle_zone_valid.yml
+++ b/spec/fixtures/cassettes/api/current_circle_zone_valid.yml
@@ -1,0 +1,122 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/find?cnt=10&lat=55.5&lon=37.5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 15:03:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - redis
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlIjoiYWNjdXJhdGUiLCJjb2QiOiIyMDAiLCJjb3VudCI6MTAs
+        Imxpc3QiOlt7ImlkIjo0OTUyNjAsIm5hbWUiOiJTaGNoZXJiaW5rYSIsImNv
+        b3JkIjp7ImxvbiI6MzcuNTU5NzE5LCJsYXQiOjU1LjQ5OTcyMn0sIm1haW4i
+        OnsidGVtcCI6Mjg4LjY4LCJwcmVzc3VyZSI6MTAxMywiaHVtaWRpdHkiOjgy
+        LCJ0ZW1wX21pbiI6Mjg0LjI2LCJ0ZW1wX21heCI6MjkxLjc1fSwiZHQiOjE0
+        NDEzNzU2MzUsIndpbmQiOnsic3BlZWQiOjMsImRlZyI6MjkwfSwic3lzIjp7
+        ImNvdW50cnkiOiIifSwiY2xvdWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVyIjpb
+        eyJpZCI6ODAzLCJtYWluIjoiQ2xvdWRzIiwiZGVzY3JpcHRpb24iOiJicm9r
+        ZW4gY2xvdWRzIiwiaWNvbiI6IjA0ZCJ9XX0seyJpZCI6NTY0NTE3LCJuYW1l
+        IjoiRHVicm92aXRzeSIsImNvb3JkIjp7ImxvbiI6MzcuNDg2Njk4LCJsYXQi
+        OjU1LjQzOTY5fSwibWFpbiI6eyJ0ZW1wIjoyODguNjgsInByZXNzdXJlIjox
+        MDEzLCJodW1pZGl0eSI6ODIsInRlbXBfbWluIjoyODQuMjYsInRlbXBfbWF4
+        IjoyOTEuNzV9LCJkdCI6MTQ0MTM3NTYzNSwid2luZCI6eyJzcGVlZCI6Mywi
+        ZGVnIjoyOTB9LCJzeXMiOnsiY291bnRyeSI6IiJ9LCJjbG91ZHMiOnsiYWxs
+        Ijo3NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMsIm1haW4iOiJDbG91ZHMiLCJk
+        ZXNjcmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMiLCJpY29uIjoiMDRkIn1dfSx7
+        ImlkIjo1NzA1NzgsIm5hbWUiOiJCdXRvdm8iLCJjb29yZCI6eyJsb24iOjM3
+        LjU3OTcyLCJsYXQiOjU1LjU0ODMyOH0sIm1haW4iOnsidGVtcCI6Mjg4Ljcy
+        LCJwcmVzc3VyZSI6MTAxMywiaHVtaWRpdHkiOjgyLCJ0ZW1wX21pbiI6Mjg3
+        LjA0LCJ0ZW1wX21heCI6MjkwLjE1fSwiZHQiOjE0NDEzNzU2MzUsIndpbmQi
+        Onsic3BlZWQiOjMsImRlZyI6MjkwfSwic3lzIjp7ImNvdW50cnkiOiIifSwi
+        Y2xvdWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVyIjpbeyJpZCI6ODAzLCJtYWlu
+        IjoiQ2xvdWRzIiwiZGVzY3JpcHRpb24iOiJicm9rZW4gY2xvdWRzIiwiaWNv
+        biI6IjA0ZCJ9XX0seyJpZCI6NTQ1NzgyLCJuYW1lIjoiS29tbXVuYXJrYSIs
+        ImNvb3JkIjp7ImxvbiI6MzcuNDg5MzE5LCJsYXQiOjU1LjU2OTUxOX0sIm1h
+        aW4iOnsidGVtcCI6Mjg4LjY3LCJwcmVzc3VyZSI6MTAxMywiaHVtaWRpdHki
+        OjgyLCJ0ZW1wX21pbiI6Mjg0LjI2LCJ0ZW1wX21heCI6MjkxLjc1fSwiZHQi
+        OjE0NDEzNzU2MzUsIndpbmQiOnsic3BlZWQiOjMsImRlZyI6MjkwfSwic3lz
+        Ijp7ImNvdW50cnkiOiIifSwiY2xvdWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVy
+        IjpbeyJpZCI6ODAzLCJtYWluIjoiQ2xvdWRzIiwiZGVzY3JpcHRpb24iOiJi
+        cm9rZW4gY2xvdWRzIiwiaWNvbiI6IjA0ZCJ9XX0seyJpZCI6NjQxNzQ5MCwi
+        bmFtZSI6Ikxlc3BhcmtraG96IiwiY29vcmQiOnsibG9uIjozNy42MDEzOTEs
+        ImxhdCI6NTUuNTQzMDZ9LCJtYWluIjp7InRlbXAiOjI4OC43MiwicHJlc3N1
+        cmUiOjEwMTMsImh1bWlkaXR5Ijo4MiwidGVtcF9taW4iOjI4Ny4wNCwidGVt
+        cF9tYXgiOjI5MC4xNX0sImR0IjoxNDQxMzc1NjM1LCJ3aW5kIjp7InNwZWVk
+        IjozLCJkZWciOjI5MH0sInN5cyI6eyJjb3VudHJ5IjoiIn0sImNsb3VkcyI6
+        eyJhbGwiOjc1fSwid2VhdGhlciI6W3siaWQiOjgwMywibWFpbiI6IkNsb3Vk
+        cyIsImRlc2NyaXB0aW9uIjoiYnJva2VuIGNsb3VkcyIsImljb24iOiIwNGQi
+        fV19LHsiaWQiOjUyNjczNiwibmFtZSI6IlNlZOKAmW1veSBNaWtyb3JheW9u
+        IiwiY29vcmQiOnsibG9uIjozNy41Nzk3MiwibGF0Ijo1NS41NjIyMjJ9LCJt
+        YWluIjp7InRlbXAiOjI4OC42OCwicHJlc3N1cmUiOjEwMTMsImh1bWlkaXR5
+        Ijo4MiwidGVtcF9taW4iOjI4Ny4wNCwidGVtcF9tYXgiOjI5MC4xNX0sImR0
+        IjoxNDQxMzc1MDM2LCJ3aW5kIjp7InNwZWVkIjozLCJkZWciOjI5MH0sInN5
+        cyI6eyJjb3VudHJ5IjoiIn0sImNsb3VkcyI6eyJhbGwiOjc1fSwid2VhdGhl
+        ciI6W3siaWQiOjgwMywibWFpbiI6IkNsb3VkcyIsImRlc2NyaXB0aW9uIjoi
+        YnJva2VuIGNsb3VkcyIsImljb24iOiIwNGQifV19LHsiaWQiOjQ3MzA1MSwi
+        bmFtZSI6IlZsYXPigJl5ZXZvIiwiY29vcmQiOnsibG9uIjozNy4zNzk0NDQs
+        ImxhdCI6NTUuNDYwMjc4fSwibWFpbiI6eyJ0ZW1wIjoyODkuMjQsInByZXNz
+        dXJlIjoxMDEzLCJodW1pZGl0eSI6ODIsInRlbXBfbWluIjoyODcuMDQsInRl
+        bXBfbWF4IjoyOTEuNzV9LCJkdCI6MTQ0MTM3NTU2NSwid2luZCI6eyJzcGVl
+        ZCI6MywiZGVnIjoyOTB9LCJzeXMiOnsiY291bnRyeSI6IiJ9LCJjbG91ZHMi
+        OnsiYWxsIjo3NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMsIm1haW4iOiJDbG91
+        ZHMiLCJkZXNjcmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMiLCJpY29uIjoiMDRk
+        In1dfSx7ImlkIjo1Nzg2ODAsIm5hbWUiOiJCYWNodXJpbm8iLCJjb29yZCI6
+        eyJsb24iOjM3LjUyLCJsYXQiOjU1LjU4MDAwMn0sIm1haW4iOnsidGVtcCI6
+        Mjg4LjcsInByZXNzdXJlIjoxMDEzLCJodW1pZGl0eSI6ODIsInRlbXBfbWlu
+        IjoyODQuMjYsInRlbXBfbWF4IjoyOTIuMzV9LCJkdCI6MTQ0MTM3NTI2Nywi
+        d2luZCI6eyJzcGVlZCI6MywiZGVnIjoyOTB9LCJzeXMiOnsiY291bnRyeSI6
+        IiJ9LCJjbG91ZHMiOnsiYWxsIjo3NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMs
+        Im1haW4iOiJDbG91ZHMiLCJkZXNjcmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMi
+        LCJpY29uIjoiMDRkIn1dfSx7ImlkIjo1NTQ2MjksIm5hbWUiOiJTaGVzdG95
+        IE1pa3JvcmF5b24iLCJjb29yZCI6eyJsb24iOjM3LjU4MzMyOCwibGF0Ijo1
+        NS41NjY2Njl9LCJtYWluIjp7InRlbXAiOjI4OC43MiwicHJlc3N1cmUiOjEw
+        MTMsImh1bWlkaXR5Ijo4MiwidGVtcF9taW4iOjI4Ny4wNCwidGVtcF9tYXgi
+        OjI5MC4xNX0sImR0IjoxNDQxMzc1NjM1LCJ3aW5kIjp7InNwZWVkIjozLCJk
+        ZWciOjI5MH0sInN5cyI6eyJjb3VudHJ5IjoiIn0sImNsb3VkcyI6eyJhbGwi
+        Ojc1fSwid2VhdGhlciI6W3siaWQiOjgwMywibWFpbiI6IkNsb3VkcyIsImRl
+        c2NyaXB0aW9uIjoiYnJva2VuIGNsb3VkcyIsImljb24iOiIwNGQifV19LHsi
+        aWQiOjUwODEwMSwibmFtZSI6IlBvZG9sc2siLCJjb29yZCI6eyJsb24iOjM3
+        LjU1NDcyMiwibGF0Ijo1NS40MjQxNzl9LCJtYWluIjp7InRlbXAiOjI4OC42
+        NywicHJlc3N1cmUiOjEwMTMsImh1bWlkaXR5Ijo4MiwidGVtcF9taW4iOjI4
+        Ny4wNCwidGVtcF9tYXgiOjI5MC4xNX0sImR0IjoxNDQxMzc1MTI1LCJ3aW5k
+        Ijp7InNwZWVkIjozLCJkZWciOjI5MH0sInN5cyI6eyJjb3VudHJ5IjoiIn0s
+        ImNsb3VkcyI6eyJhbGwiOjc1fSwid2VhdGhlciI6W3siaWQiOjgwMywibWFp
+        biI6IkNsb3VkcyIsImRlc2NyaXB0aW9uIjoiYnJva2VuIGNsb3VkcyIsImlj
+        b24iOiIwNGQifV19XX0K
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 15:03:11 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/api/current_cities_invalid.yml
+++ b/spec/fixtures/cassettes/api/current_cities_invalid.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/group?id=42,1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Sep 2015 18:55:49 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - redis
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"cnt":0,"list":[]}
+    http_version: 
+  recorded_at: Thu, 03 Sep 2015 18:55:48 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/api/current_cities_valid.yml
+++ b/spec/fixtures/cassettes/api/current_cities_valid.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/group?id=524901,703448,2643743
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Sep 2015 18:55:49 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - redis
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"cnt":3,"list":[{"coord":{"lon":37.62,"lat":55.75},"sys":{"type":1,"id":7323,"message":0.0092,"country":"RU","sunrise":1441247914,"sunset":1441297148},"weather":[{"id":520,"main":"Rain","description":"light intensity shower rain","icon":"09n"}],"main":{"temp":286.95,"pressure":1014,"humidity":82,"temp_min":286.15,"temp_max":287.15},"visibility":10000,"wind":{"speed":3,"deg":110},"clouds":{"all":75},"dt":1441305544,"id":524901,"name":"Moscow"},{"coord":{"lon":30.52,"lat":50.43},"sys":{"type":1,"id":7358,"message":0.0036,"country":"UA","sunrise":1441250136,"sunset":1441298334},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01n"}],"main":{"temp":294.91,"pressure":1013,"humidity":69,"temp_min":294.15,"temp_max":296.15},"wind":{"speed":2,"deg":350,"var_beg":300,"var_end":20},"clouds":{"all":0},"dt":1441305454,"id":703448,"name":"Kiev"},{"coord":{"lon":-0.13,"lat":51.51},"sys":{"type":1,"id":5093,"message":0.0047,"country":"GB","sunrise":1441257404,"sunset":1441305770},"weather":[{"id":520,"main":"Rain","description":"light intensity shower rain","icon":"09d"}],"main":{"temp":285.86,"pressure":1016,"humidity":76,"temp_min":284.15,"temp_max":287.15},"wind":{"speed":2.6,"deg":10,"var_beg":330,"var_end":40},"clouds":{"all":40},"dt":1441305650,"id":2643743,"name":"London"}]}
+    http_version: 
+  recorded_at: Thu, 03 Sep 2015 18:55:48 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/api/current_rectangle_zone_invalid.yml
+++ b/spec/fixtures/cassettes/api/current_rectangle_zone_invalid.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/box/city?bbox=-5,-5,-5,-5,-5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 14:51:02 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - back
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"message":"","cod":"200","cnt":0,"list":[]}
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 14:51:01 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/api/current_rectangle_zone_valid.yml
+++ b/spec/fixtures/cassettes/api/current_rectangle_zone_valid.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/box/city?bbox=12,32,15,37,10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 14:51:02 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - back
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"cod":"200","calctime":0.52,"cnt":15,"list":[{"id":2208791,"name":"Yafran","coord":{"lon":12.52859,"lat":32.06329},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2208425,"name":"Zuwarah","coord":{"lon":12.08199,"lat":32.931198},"main":{"temp":35.42,"temp_min":35.416,"temp_max":35.416,"pressure":1024.08,"sea_level":1025.06,"grnd_level":1024.08,"humidity":45},"dt":1441374579,"wind":{"speed":4.27,"deg":91.0012},"clouds":{"all":36},"weather":[{"id":802,"main":"Clouds","description":"scattered clouds","icon":"03d"}]},{"id":2212771,"name":"Sabratah","coord":{"lon":12.48845,"lat":32.79335},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2217362,"name":"Gharyan","coord":{"lon":13.02028,"lat":32.172218},"main":{"temp":38.82,"temp_min":38.816,"temp_max":38.816,"pressure":994.49,"sea_level":1025.88,"grnd_level":994.49,"humidity":18},"dt":1441374580,"wind":{"speed":1.67,"deg":202.001},"clouds":{"all":20},"weather":[{"id":801,"main":"Clouds","description":"few clouds","icon":"02d"}]},{"id":2216885,"name":"Zawiya","coord":{"lon":12.72778,"lat":32.75222},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2210247,"name":"Tripoli","coord":{"lon":13.18746,"lat":32.875191},"main":{"temp":30.87,"temp_min":30.866,"temp_max":30.866,"pressure":1024.65,"sea_level":1025.96,"grnd_level":1024.65,"humidity":80},"dt":1441374580,"wind":{"speed":7.87,"deg":75.0012},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2210221,"name":"Tarhuna","coord":{"lon":13.6332,"lat":32.43502},"main":{"temp":39.37,"temp_min":39.366,"temp_max":39.366,"pressure":994.33,"sea_level":1026.32,"grnd_level":994.33,"humidity":16},"dt":1441374580,"wind":{"speed":2.82,"deg":135.501},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2215163,"name":"Masallatah","coord":{"lon":14,"lat":32.616669},"main":{"temp":37.6,"temp_min":37.597,"temp_max":37.597,"pressure":1014.56,"sea_level":1027.72,"grnd_level":1014.56,"humidity":23},"dt":1441374580,"wind":{"speed":4.06,"deg":81.0002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2219905,"name":"Al Khums","coord":{"lon":14.26191,"lat":32.648609},"main":{"temp":37.6,"temp_min":37.597,"temp_max":37.597,"pressure":1014.56,"sea_level":1027.72,"grnd_level":1014.56,"humidity":23},"dt":1441374581,"wind":{"speed":4.06,"deg":81.0002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2208485,"name":"Zlitan","coord":{"lon":14.56874,"lat":32.467381},"main":{"temp":38.22,"temp_min":38.216,"temp_max":38.216,"pressure":1013.62,"sea_level":1026.85,"grnd_level":1013.62,"humidity":24},"dt":1441374580,"wind":{"speed":3.87,"deg":91.5012},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2563191,"name":"Birkirkara","coord":{"lon":14.46111,"lat":35.897221},"main":{"temp":33.65,"pressure":1015,"humidity":36,"temp_min":32.6,"temp_max":34.44},"dt":1441374636,"wind":{"speed":3.1,"deg":240,"var_beg":190,"var_end":270},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523650,"name":"Ragusa","coord":{"lon":14.71719,"lat":36.928242},"main":{"temp":34.26,"pressure":1013,"humidity":35,"temp_min":31,"temp_max":37},"dt":1441374630,"wind":{"speed":6.2,"deg":60},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523693,"name":"Pozzallo","coord":{"lon":14.84989,"lat":36.730541},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374630,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2524119,"name":"Modica","coord":{"lon":14.77399,"lat":36.84594},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374631,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523581,"name":"Rosolini","coord":{"lon":14.94779,"lat":36.824242},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374630,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]}]}
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 14:51:01 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/integration/current_by_circle_zone.yml
+++ b/spec/fixtures/cassettes/integration/current_by_circle_zone.yml
@@ -1,0 +1,121 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/find?APPID=1111111111&cnt=10&lat=55.5&lon=37.5&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 15:08:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - back
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlIjoiYWNjdXJhdGUiLCJjb2QiOiIyMDAiLCJjb3VudCI6MTAs
+        Imxpc3QiOlt7ImlkIjo0OTUyNjAsIm5hbWUiOiJTaGNoZXJiaW5rYSIsImNv
+        b3JkIjp7ImxvbiI6MzcuNTU5NzE5LCJsYXQiOjU1LjQ5OTcyMn0sIm1haW4i
+        OnsidGVtcCI6MTUuNjcsInByZXNzdXJlIjoxMDEyLCJodW1pZGl0eSI6Nzcs
+        InRlbXBfbWluIjoxNC40NCwidGVtcF9tYXgiOjE3fSwiZHQiOjE0NDEzNzkw
+        MjgsIndpbmQiOnsic3BlZWQiOjMsImRlZyI6MzIwfSwic3lzIjp7ImNvdW50
+        cnkiOiIifSwiY2xvdWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVyIjpbeyJpZCI6
+        ODAzLCJtYWluIjoiQ2xvdWRzIiwiZGVzY3JpcHRpb24iOiJicm9rZW4gY2xv
+        dWRzIiwiaWNvbiI6IjA0ZCJ9XX0seyJpZCI6NTY0NTE3LCJuYW1lIjoiRHVi
+        cm92aXRzeSIsImNvb3JkIjp7ImxvbiI6MzcuNDg2Njk4LCJsYXQiOjU1LjQz
+        OTY5fSwibWFpbiI6eyJ0ZW1wIjoxNS40NiwicHJlc3N1cmUiOjEwMTIsImh1
+        bWlkaXR5Ijo3NywidGVtcF9taW4iOjExLjExLCJ0ZW1wX21heCI6MTcuNH0s
+        ImR0IjoxNDQxMzc4NTQzLCJ3aW5kIjp7InNwZWVkIjozLCJkZWciOjMyMH0s
+        InN5cyI6eyJjb3VudHJ5IjoiIn0sImNsb3VkcyI6eyJhbGwiOjc1fSwid2Vh
+        dGhlciI6W3siaWQiOjgwMywibWFpbiI6IkNsb3VkcyIsImRlc2NyaXB0aW9u
+        IjoiYnJva2VuIGNsb3VkcyIsImljb24iOiIwNGQifV19LHsiaWQiOjU3MDU3
+        OCwibmFtZSI6IkJ1dG92byIsImNvb3JkIjp7ImxvbiI6MzcuNTc5NzIsImxh
+        dCI6NTUuNTQ4MzI4fSwibWFpbiI6eyJ0ZW1wIjoxNS42NywicHJlc3N1cmUi
+        OjEwMTIsImh1bWlkaXR5Ijo3NywidGVtcF9taW4iOjE0LjQ0LCJ0ZW1wX21h
+        eCI6MTd9LCJkdCI6MTQ0MTM3OTAyOCwid2luZCI6eyJzcGVlZCI6MywiZGVn
+        IjozMjB9LCJzeXMiOnsiY291bnRyeSI6IiJ9LCJjbG91ZHMiOnsiYWxsIjo3
+        NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMsIm1haW4iOiJDbG91ZHMiLCJkZXNj
+        cmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMiLCJpY29uIjoiMDRkIn1dfSx7Imlk
+        Ijo1NDU3ODIsIm5hbWUiOiJLb21tdW5hcmthIiwiY29vcmQiOnsibG9uIjoz
+        Ny40ODkzMTksImxhdCI6NTUuNTY5NTE5fSwibWFpbiI6eyJ0ZW1wIjoxNS40
+        NiwicHJlc3N1cmUiOjEwMTIsImh1bWlkaXR5Ijo3NywidGVtcF9taW4iOjEx
+        LjExLCJ0ZW1wX21heCI6MTcuNH0sImR0IjoxNDQxMzc5MDI4LCJ3aW5kIjp7
+        InNwZWVkIjozLCJkZWciOjMyMH0sInN5cyI6eyJjb3VudHJ5IjoiIn0sImNs
+        b3VkcyI6eyJhbGwiOjc1fSwid2VhdGhlciI6W3siaWQiOjgwMywibWFpbiI6
+        IkNsb3VkcyIsImRlc2NyaXB0aW9uIjoiYnJva2VuIGNsb3VkcyIsImljb24i
+        OiIwNGQifV19LHsiaWQiOjY0MTc0OTAsIm5hbWUiOiJMZXNwYXJra2hveiIs
+        ImNvb3JkIjp7ImxvbiI6MzcuNjAxMzkxLCJsYXQiOjU1LjU0MzA2fSwibWFp
+        biI6eyJ0ZW1wIjoxNS42NywicHJlc3N1cmUiOjEwMTIsImh1bWlkaXR5Ijo3
+        NywidGVtcF9taW4iOjE0LjQ0LCJ0ZW1wX21heCI6MTd9LCJkdCI6MTQ0MTM3
+        OTAyOCwid2luZCI6eyJzcGVlZCI6MywiZGVnIjozMjB9LCJzeXMiOnsiY291
+        bnRyeSI6IiJ9LCJjbG91ZHMiOnsiYWxsIjo3NX0sIndlYXRoZXIiOlt7Imlk
+        Ijo4MDMsIm1haW4iOiJDbG91ZHMiLCJkZXNjcmlwdGlvbiI6ImJyb2tlbiBj
+        bG91ZHMiLCJpY29uIjoiMDRkIn1dfSx7ImlkIjo1MjY3MzYsIm5hbWUiOiJT
+        ZWTigJltb3kgTWlrcm9yYXlvbiIsImNvb3JkIjp7ImxvbiI6MzcuNTc5NzIs
+        ImxhdCI6NTUuNTYyMjIyfSwibWFpbiI6eyJ0ZW1wIjoxNS42NywicHJlc3N1
+        cmUiOjEwMTIsImh1bWlkaXR5Ijo3NywidGVtcF9taW4iOjE0LjQ0LCJ0ZW1w
+        X21heCI6MTd9LCJkdCI6MTQ0MTM3OTAyOCwid2luZCI6eyJzcGVlZCI6Mywi
+        ZGVnIjozMjB9LCJzeXMiOnsiY291bnRyeSI6IiJ9LCJjbG91ZHMiOnsiYWxs
+        Ijo3NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMsIm1haW4iOiJDbG91ZHMiLCJk
+        ZXNjcmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMiLCJpY29uIjoiMDRkIn1dfSx7
+        ImlkIjo0NzMwNTEsIm5hbWUiOiJWbGFz4oCZeWV2byIsImNvb3JkIjp7Imxv
+        biI6MzcuMzc5NDQ0LCJsYXQiOjU1LjQ2MDI3OH0sIm1haW4iOnsidGVtcCI6
+        MTYuMDIsInByZXNzdXJlIjoxMDEyLCJodW1pZGl0eSI6NzcsInRlbXBfbWlu
+        IjoxNC40NCwidGVtcF9tYXgiOjE3LjR9LCJkdCI6MTQ0MTM3OTAyOCwid2lu
+        ZCI6eyJzcGVlZCI6MywiZGVnIjozMjB9LCJzeXMiOnsiY291bnRyeSI6IiJ9
+        LCJjbG91ZHMiOnsiYWxsIjo3NX0sIndlYXRoZXIiOlt7ImlkIjo4MDMsIm1h
+        aW4iOiJDbG91ZHMiLCJkZXNjcmlwdGlvbiI6ImJyb2tlbiBjbG91ZHMiLCJp
+        Y29uIjoiMDRkIn1dfSx7ImlkIjo1Nzg2ODAsIm5hbWUiOiJCYWNodXJpbm8i
+        LCJjb29yZCI6eyJsb24iOjM3LjUyLCJsYXQiOjU1LjU4MDAwMn0sIm1haW4i
+        OnsidGVtcCI6MTUuNjcsInByZXNzdXJlIjoxMDEyLCJodW1pZGl0eSI6Nzcs
+        InRlbXBfbWluIjoxNC40NCwidGVtcF9tYXgiOjE3fSwiZHQiOjE0NDEzNzkw
+        MjgsIndpbmQiOnsic3BlZWQiOjMsImRlZyI6MzIwfSwic3lzIjp7ImNvdW50
+        cnkiOiIifSwiY2xvdWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVyIjpbeyJpZCI6
+        ODAzLCJtYWluIjoiQ2xvdWRzIiwiZGVzY3JpcHRpb24iOiJicm9rZW4gY2xv
+        dWRzIiwiaWNvbiI6IjA0ZCJ9XX0seyJpZCI6NTU0NjI5LCJuYW1lIjoiU2hl
+        c3RveSBNaWtyb3JheW9uIiwiY29vcmQiOnsibG9uIjozNy41ODMzMjgsImxh
+        dCI6NTUuNTY2NjY5fSwibWFpbiI6eyJ0ZW1wIjoxNS4zNywicHJlc3N1cmUi
+        OjEwMTIsImh1bWlkaXR5Ijo3NywidGVtcF9taW4iOjExLjExLCJ0ZW1wX21h
+        eCI6MTcuNH0sImR0IjoxNDQxMzc5MTU2LCJ3aW5kIjp7InNwZWVkIjozLCJk
+        ZWciOjMyMH0sInN5cyI6eyJjb3VudHJ5IjoiIn0sImNsb3VkcyI6eyJhbGwi
+        Ojc1fSwid2VhdGhlciI6W3siaWQiOjgwMywibWFpbiI6IkNsb3VkcyIsImRl
+        c2NyaXB0aW9uIjoiYnJva2VuIGNsb3VkcyIsImljb24iOiIwNGQifV19LHsi
+        aWQiOjUwODEwMSwibmFtZSI6IlBvZG9sc2siLCJjb29yZCI6eyJsb24iOjM3
+        LjU1NDcyMiwibGF0Ijo1NS40MjQxNzl9LCJtYWluIjp7InRlbXAiOjE1LjY2
+        LCJwcmVzc3VyZSI6MTAxMiwiaHVtaWRpdHkiOjc3LCJ0ZW1wX21pbiI6MTEu
+        MTEsInRlbXBfbWF4IjoxNy40fSwiZHQiOjE0NDEzNzg2MjEsIndpbmQiOnsi
+        c3BlZWQiOjMsImRlZyI6MzIwfSwic3lzIjp7ImNvdW50cnkiOiIifSwiY2xv
+        dWRzIjp7ImFsbCI6NzV9LCJ3ZWF0aGVyIjpbeyJpZCI6ODAzLCJtYWluIjoi
+        Q2xvdWRzIiwiZGVzY3JpcHRpb24iOiJicm9rZW4gY2xvdWRzIiwiaWNvbiI6
+        IjA0ZCJ9XX1dfQo=
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 15:08:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/integration/current_by_cities.yml
+++ b/spec/fixtures/cassettes/integration/current_by_cities.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/group?APPID=1111111111&id=524901,703448,2643743&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Sep 2015 18:55:49 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - back
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"cnt":3,"list":[{"coord":{"lon":37.62,"lat":55.75},"sys":{"type":1,"id":7323,"message":0.0059,"country":"RU","sunrise":1441247914,"sunset":1441297148},"weather":[{"id":520,"main":"Rain","description":"light intensity shower rain","icon":"09n"}],"main":{"temp":13.41,"pressure":1014,"humidity":82,"temp_min":11.11,"temp_max":14.8},"wind":{"speed":3,"deg":110},"clouds":{"all":75},"dt":1441306336,"id":524901,"name":"Moscow"},{"coord":{"lon":30.52,"lat":50.43},"sys":{"type":1,"id":7358,"message":0.0036,"country":"UA","sunrise":1441250136,"sunset":1441298334},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01n"}],"main":{"temp":21.76,"pressure":1013,"humidity":69,"temp_min":21,"temp_max":23},"wind":{"speed":2,"deg":350,"var_beg":300,"var_end":20},"clouds":{"all":0},"dt":1441305454,"id":703448,"name":"Kiev"},{"coord":{"lon":-0.13,"lat":51.51},"sys":{"type":1,"id":5093,"message":0.0037,"country":"GB","sunrise":1441257404,"sunset":1441305770},"weather":[{"id":520,"main":"Rain","description":"light intensity shower rain","icon":"09n"}],"main":{"temp":12.76,"pressure":1016,"humidity":76,"temp_min":11,"temp_max":15},"wind":{"speed":2.6,"deg":10,"var_beg":330,"var_end":40},"clouds":{"all":40},"dt":1441306250,"id":2643743,"name":"London"}]}
+    http_version: 
+  recorded_at: Thu, 03 Sep 2015 18:55:48 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/cassettes/integration/current_by_rectangle_zone.yml
+++ b/spec/fixtures/cassettes/integration/current_by_rectangle_zone.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/box/city?APPID=1111111111&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 14:48:25 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - redis
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"message":"","cod":"500"}
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 14:48:24 GMT
+- request:
+    method: get
+    uri: http://api.openweathermap.org/data/2.5/box/city?APPID=1111111111&bbox=12,32,15,37,10&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.openweathermap.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 04 Sep 2015 14:51:01 GMT
+      Content-Type:
+      - application/json; charset=utf8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Source:
+      - back
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: |
+        {"cod":"200","calctime":1.152,"cnt":15,"list":[{"id":2208791,"name":"Yafran","coord":{"lon":12.52859,"lat":32.06329},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2208425,"name":"Zuwarah","coord":{"lon":12.08199,"lat":32.931198},"main":{"temp":35.42,"temp_min":35.416,"temp_max":35.416,"pressure":1024.08,"sea_level":1025.06,"grnd_level":1024.08,"humidity":45},"dt":1441374579,"wind":{"speed":4.27,"deg":91.0012},"clouds":{"all":36},"weather":[{"id":802,"main":"Clouds","description":"scattered clouds","icon":"03d"}]},{"id":2212771,"name":"Sabratah","coord":{"lon":12.48845,"lat":32.79335},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2217362,"name":"Gharyan","coord":{"lon":13.02028,"lat":32.172218},"main":{"temp":38.82,"temp_min":38.816,"temp_max":38.816,"pressure":994.49,"sea_level":1025.88,"grnd_level":994.49,"humidity":18},"dt":1441374580,"wind":{"speed":1.67,"deg":202.001},"clouds":{"all":20},"weather":[{"id":801,"main":"Clouds","description":"few clouds","icon":"02d"}]},{"id":2216885,"name":"Zawiya","coord":{"lon":12.72778,"lat":32.75222},"main":{"temp":39.75,"temp_min":39.747,"temp_max":39.747,"pressure":1006.69,"sea_level":1026.3,"grnd_level":1006.69,"humidity":21},"dt":1441374580,"wind":{"speed":2.71,"deg":38.5002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2210247,"name":"Tripoli","coord":{"lon":13.18746,"lat":32.875191},"main":{"temp":30.87,"temp_min":30.866,"temp_max":30.866,"pressure":1024.65,"sea_level":1025.96,"grnd_level":1024.65,"humidity":80},"dt":1441374580,"wind":{"speed":7.87,"deg":75.0012},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2210221,"name":"Tarhuna","coord":{"lon":13.6332,"lat":32.43502},"main":{"temp":39.37,"temp_min":39.366,"temp_max":39.366,"pressure":994.33,"sea_level":1026.32,"grnd_level":994.33,"humidity":16},"dt":1441374580,"wind":{"speed":2.82,"deg":135.501},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2215163,"name":"Masallatah","coord":{"lon":14,"lat":32.616669},"main":{"temp":37.6,"temp_min":37.597,"temp_max":37.597,"pressure":1014.56,"sea_level":1027.72,"grnd_level":1014.56,"humidity":23},"dt":1441374580,"wind":{"speed":4.06,"deg":81.0002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2219905,"name":"Al Khums","coord":{"lon":14.26191,"lat":32.648609},"main":{"temp":37.6,"temp_min":37.597,"temp_max":37.597,"pressure":1014.56,"sea_level":1027.72,"grnd_level":1014.56,"humidity":23},"dt":1441374581,"wind":{"speed":4.06,"deg":81.0002},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2208485,"name":"Zlitan","coord":{"lon":14.56874,"lat":32.467381},"main":{"temp":38.22,"temp_min":38.216,"temp_max":38.216,"pressure":1013.62,"sea_level":1026.85,"grnd_level":1013.62,"humidity":24},"dt":1441374580,"wind":{"speed":3.87,"deg":91.5012},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2563191,"name":"Birkirkara","coord":{"lon":14.46111,"lat":35.897221},"main":{"temp":33.65,"pressure":1015,"humidity":36,"temp_min":32.6,"temp_max":34.44},"dt":1441374636,"wind":{"speed":3.1,"deg":240,"var_beg":190,"var_end":270},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523650,"name":"Ragusa","coord":{"lon":14.71719,"lat":36.928242},"main":{"temp":34.26,"pressure":1013,"humidity":35,"temp_min":31,"temp_max":37},"dt":1441374630,"wind":{"speed":6.2,"deg":60},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523693,"name":"Pozzallo","coord":{"lon":14.84989,"lat":36.730541},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374630,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2524119,"name":"Modica","coord":{"lon":14.77399,"lat":36.84594},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374631,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]},{"id":2523581,"name":"Rosolini","coord":{"lon":14.94779,"lat":36.824242},"main":{"temp":28.35,"temp_min":28.347,"temp_max":28.347,"pressure":1026.39,"sea_level":1028.41,"grnd_level":1026.39,"humidity":94},"dt":1441374630,"wind":{"speed":4.11,"deg":242.5},"clouds":{"all":0},"weather":[{"id":800,"main":"Clear","description":"Sky is Clear","icon":"01d"}]}]}
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 14:51:00 GMT
+recorded_with: VCR 2.9.3

--- a/spec/integration/current_spec.rb
+++ b/spec/integration/current_spec.rb
@@ -84,4 +84,20 @@ describe 'Current weather information with APPID' do
       expect(weather['list']).to be_kind_of(Array)
     end
   end
+
+  describe 'searching by cycle' do
+    let(:weather) do
+      VCR.use_cassette('integration/current_by_circle_zone') do
+        OpenWeather::Current.circle_zone(55.5, 37.5, 10, options)
+      end
+    end
+
+    it 'returns results' do
+      expect(weather).to include('list')
+    end
+
+    it 'returns results as an array' do
+      expect(weather['list']).to be_kind_of(Array)
+    end
+  end
 end

--- a/spec/integration/current_spec.rb
+++ b/spec/integration/current_spec.rb
@@ -52,4 +52,20 @@ describe 'Current weather information with APPID' do
       expect(weather).to include('weather')
     end
   end
+
+  describe 'searching by city ids' do
+    let(:weather) do
+      VCR.use_cassette('integration/current_by_cities') do
+        OpenWeather::Current.cities([524901,703448,2643743], options)
+      end
+    end
+
+    it 'returns results' do
+      expect(weather).to inclue('weather')
+    end
+
+    it 'returns an array' do
+      expect(weather).to be_kind_of(Array)
+    end
+  end
 end

--- a/spec/integration/current_spec.rb
+++ b/spec/integration/current_spec.rb
@@ -61,11 +61,11 @@ describe 'Current weather information with APPID' do
     end
 
     it 'returns results' do
-      expect(weather).to inclue('weather')
+      expect(weather).to include('list')
     end
 
-    it 'returns an array' do
-      expect(weather).to be_kind_of(Array)
+    it 'returns results as an array' do
+      expect(weather['list']).to be_kind_of(Array)
     end
   end
 end

--- a/spec/integration/current_spec.rb
+++ b/spec/integration/current_spec.rb
@@ -56,7 +56,23 @@ describe 'Current weather information with APPID' do
   describe 'searching by city ids' do
     let(:weather) do
       VCR.use_cassette('integration/current_by_cities') do
-        OpenWeather::Current.cities([524901,703448,2643743], options)
+        OpenWeather::Current.cities([524901, 703448, 2643743], options)
+      end
+    end
+
+    it 'returns results' do
+      expect(weather).to include('list')
+    end
+
+    it 'returns results as an array' do
+      expect(weather['list']).to be_kind_of(Array)
+    end
+  end
+
+  describe 'searching by bounding box' do
+    let(:weather) do
+      VCR.use_cassette('integration/current_by_rectangle_zone') do
+        OpenWeather::Current.rectangle_zone(12, 32, 15, 37, 10, options)
       end
     end
 

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -79,6 +79,22 @@ describe 'Open weather Current API' do
     end
   end
 
+  context '.circle_zone' do
+    it 'return current weather for the cities in cycle' do
+      response = VCR.use_cassette('api/current_circle_zone_valid') do
+        OpenWeather::Current.circle_zone(55.5, 37.5, 10)
+      end
+      response['count'].should eq(10) # exceptionally called `count` here
+    end
+
+    it 'return error if count is negative' do
+      response = VCR.use_cassette('api/current_circle_zone_invalid') do
+        OpenWeather::Current.circle_zone(55.5, 37.5, -10)
+      end
+      response['cod'].should eq("500")
+    end
+  end
+
   context 'units option' do
     it 'returns the current temperature in requested units' do
       response = VCR.use_cassette('api/current_city_metric_valid') do

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -47,6 +47,22 @@ describe 'Open weather Current API' do
     end
   end
 
+  context '.cities' do
+    it 'return current weather for list of cities' do
+      response = VCR.use_cassette('api/current_cities_valid') do
+        OpenWeather::Current.cities([524901,703448,2643743])
+      end
+      response['cod'].should eq(200)
+    end
+
+    it 'return error if list of cities is invalid' do
+      response = VCR.use_cassette('api/current_cities_valid') do
+        OpenWeather::Current.cities([42,1000])
+      end
+      response['cod'].should eq('404')
+    end
+  end
+
   context 'units option' do
     it 'returns the current temperature in requested units' do
       response = VCR.use_cassette('api/current_city_metric_valid') do

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -50,14 +50,30 @@ describe 'Open weather Current API' do
   context '.cities' do
     it 'return current weather for list of cities' do
       response = VCR.use_cassette('api/current_cities_valid') do
-        OpenWeather::Current.cities([524901,703448,2643743])
+        OpenWeather::Current.cities([524901, 703448, 2643743])
       end
       response['cnt'].should eq(3)
     end
 
     it 'return empty list if cities are invalid' do
       response = VCR.use_cassette('api/current_cities_invalid') do
-        OpenWeather::Current.cities([42,1000])
+        OpenWeather::Current.cities([42, 1000])
+      end
+      response['cnt'].should eq(0)
+    end
+  end
+
+  context '.rectangle_zone' do
+    it 'return current weather for the cities in a bounding box' do
+      response = VCR.use_cassette('api/current_rectangle_zone_valid') do
+        OpenWeather::Current.rectangle_zone(12, 32, 15, 37, 10)
+      end
+      response['cnt'].should eq(15)
+    end
+
+    it 'return empty list if bounding box is invalid' do
+      response = VCR.use_cassette('api/current_rectangle_zone_invalid') do
+        OpenWeather::Current.rectangle_zone(-5, -5, -5, -5, -5)
       end
       response['cnt'].should eq(0)
     end

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -52,14 +52,14 @@ describe 'Open weather Current API' do
       response = VCR.use_cassette('api/current_cities_valid') do
         OpenWeather::Current.cities([524901,703448,2643743])
       end
-      response['cod'].should eq(200)
+      response['cnt'].should eq(3)
     end
 
-    it 'return error if list of cities is invalid' do
-      response = VCR.use_cassette('api/current_cities_valid') do
+    it 'return empty list if cities are invalid' do
+      response = VCR.use_cassette('api/current_cities_invalid') do
         OpenWeather::Current.cities([42,1000])
       end
-      response['cod'].should eq('404')
+      response['cnt'].should eq(0)
     end
   end
 

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -52,14 +52,14 @@ describe 'Open weather Current API' do
       response = VCR.use_cassette('api/current_cities_valid') do
         OpenWeather::Current.cities([524901, 703448, 2643743])
       end
-      response['cnt'].should eq(3)
+      response['list'].count.should eq(3)
     end
 
     it 'return empty list if cities are invalid' do
       response = VCR.use_cassette('api/current_cities_invalid') do
         OpenWeather::Current.cities([42, 1000])
       end
-      response['cnt'].should eq(0)
+      response['list'].count.should eq(0)
     end
   end
 
@@ -68,14 +68,14 @@ describe 'Open weather Current API' do
       response = VCR.use_cassette('api/current_rectangle_zone_valid') do
         OpenWeather::Current.rectangle_zone(12, 32, 15, 37, 10)
       end
-      response['cnt'].should eq(15)
+      response['list'].count.should eq(15)
     end
 
     it 'return empty list if bounding box is invalid' do
       response = VCR.use_cassette('api/current_rectangle_zone_invalid') do
         OpenWeather::Current.rectangle_zone(-5, -5, -5, -5, -5)
       end
-      response['cnt'].should eq(0)
+      response['list'].count.should eq(0)
     end
   end
 
@@ -84,7 +84,7 @@ describe 'Open weather Current API' do
       response = VCR.use_cassette('api/current_circle_zone_valid') do
         OpenWeather::Current.circle_zone(55.5, 37.5, 10)
       end
-      response['count'].should eq(10) # exceptionally called `count` here
+      response['list'].count.should eq(10)
     end
 
     it 'return error if count is negative' do

--- a/spec/open_weather/version_spec.rb
+++ b/spec/open_weather/version_spec.rb
@@ -1,5 +1,5 @@
 describe 'Version' do
-  it 'should be version 0.11.0' do
-    OpenWeather::VERSION.should == '0.11.0'
+  it 'should be version 0.12.0' do
+    OpenWeather::VERSION.should == '0.12.0'
   end
 end


### PR DESCRIPTION
As per issue #23, this adds support for the 3 API calls to get the weather for several cities at once:

- `cities`: from a list of city IDs

- `rectangle_zone`: from a bounding box

- `circle_zone`: from a point and a count of cities to return

These only apply to `Current`, so I added class methods in `api.rb` (`SeveralCitiesClassMethods`) and then extend `Current` to get them.

I added an optional parameter to `retrieve` and `send_request` to add the possibility to "*force*" a different URL than the one specified by the class (in this case, the 3 URLs are different than the usual `Current` base URL).

I figured I would bump up the version number to `0.12.0`, as this adds to the API.

Please let me know if I should change anything or if you have ideas on how to improve this PR. Thank you!
