### PR TITLE
Raise error when exceeding city IDs limit of 20

### DIFF
--- a/lib/open_weather.rb
+++ b/lib/open_weather.rb
@@ -9,4 +9,5 @@ module OpenWeather
   autoload :VERSION,       'open_weather/version'
 
   require 'open_weather/api.rb'
+  require 'open_weather/exceptions.rb'
 end

--- a/lib/open_weather/api.rb
+++ b/lib/open_weather/api.rb
@@ -20,9 +20,20 @@ module OpenWeather
   end
 
   module SeveralCitiesClassMethods
+    # Max amount of city IDs that can be requested at once,
+    # from http://openweathermap.org/current
+    LOCATIONS_LIMIT = 20
+
     # City Ids, an array of integer values. Eg, [2172797, 524901]
     # Usage: OpenWeather::Current.cities([2172797, 524901])
+    #
+    # Note that every ID in the array counts as an API call.
+    # A LocationsLimitExceeded error is raised if the API limit is exceeded.
     def cities(ids, options = {})
+      if ids.length > SeveralCitiesClassMethods::LOCATIONS_LIMIT
+        raise LocationsLimitExceeded
+      end
+
       url = 'http://api.openweathermap.org/data/2.5/group'
       ids = encode_array ids
       new(options.merge(id: ids)).retrieve url

--- a/lib/open_weather/exceptions.rb
+++ b/lib/open_weather/exceptions.rb
@@ -1,0 +1,11 @@
+module OpenWeather
+
+  # OpenWeather imposes a limit on the amount of city IDs requested at once,
+  # see http://openweathermap.org/current
+  class LocationsLimitExceeded < StandardError
+    def initialize(msg="Too many city IDs requested at once")
+      super
+    end
+  end
+
+end

--- a/spec/open_weather/api_spec.rb
+++ b/spec/open_weather/api_spec.rb
@@ -61,6 +61,12 @@ describe 'Open weather Current API' do
       end
       response['list'].count.should eq(0)
     end
+
+    it 'raises a LocationsLimitExceeded exception with too many city IDs' do
+      expect {
+        OpenWeather::Current.cities([0] * 1000)
+      }.to raise_error OpenWeather::LocationsLimitExceeded
+    end
   end
 
   context '.rectangle_zone' do


### PR DESCRIPTION
As can be seen on [the documentation for the 'several cities' call](http://openweathermap.org/current), there is now a limit on the list of city IDs requested at once : 

> The limit of locations is 20.
 NOTE: A single ID counts as a one API call! So, the above example is treated as a 3 API calls.


I encountered this error recently as it was working properly with 24 cities before (I guess they changed their behavior) and the API failed to find the `list` parameter in :

```
{"cod"=>"400", "message"=>"id list must be in range from 1 to 20"}
```

This PR should make the limitation more obvious to anyone else the encounters it.

I toyed with the idea of magically calling the `openweather` API in batches of 20 cities, but I think that would hide the fact that `"A single ID counts as one API call"`, which is important to take into account.
I also would have preferred to raise that error based on a specific return `cod` instead of hardcoding the `20` limit, but `400` is a bit too generic here... Having the constant in the API at least makes it easier for a user of this library to batch the calls.